### PR TITLE
chore: update config of start operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,8 @@ client.PipelineClient.createUserPipelineMutation("<userName>",
           "configuration": {
             "metadata": {
               "text": {
-                "type": "text",
+                "instillFormat": "string",
+                "type": "string",
                 "title": "text"
               }
             }

--- a/src/tests/recipePayload.json
+++ b/src/tests/recipePayload.json
@@ -9,7 +9,8 @@
         "configuration": {
           "metadata": {
             "text": {
-              "type": "text",
+              "instillFormat": "string",
+              "type": "string",
               "title": "text"
             }
           }


### PR DESCRIPTION
Because

- the config format of start operator has been changed

This commit

- update config of start operator
