### PR TITLE
chore: namananand/ins 3306 use new namespace from @instill-ai/typescript-sdk --> instill-sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 Typescript SDK for Instill AI products
 
 [![Unix Build Status](https://img.shields.io/github/actions/workflow/status/instill-ai/typescript-sdk/test.yml?branch=main&label=linux)](https://github.com/instill-ai/typescript-sdk/actions)
-[![NPM License](https://img.shields.io/npm/l/@instill-ai/typescript-sdk.svg)](https://www.npmjs.com/package/@instill-ai/typescript-sdk)
-[![NPM Version](https://img.shields.io/npm/v/@instill-ai/typescript-sdk.svg)](https://www.npmjs.com/package/@instill-ai/typescript-sdk)
-[![NPM Downloads](https://img.shields.io/npm/dm/@instill-ai/typescript-sdk.svg?color=orange)](https://www.npmjs.com/package/@instill-ai/typescript-sdk)
+[![NPM License](https://img.shields.io/npm/l/instill-sdk.svg)](https://www.npmjs.com/package/instill-sdk)
+[![NPM Version](https://img.shields.io/npm/v/instill-sdk.svg)](https://www.npmjs.com/package/instill-sdk)
+[![NPM Downloads](https://img.shields.io/npm/dm/instill-sdk.svg?color=orange)](https://www.npmjs.com/package/instill-sdk)
 
 > [!IMPORTANT]  
 > **This SDK tool is under heavy development!!**  
@@ -21,25 +21,25 @@ Typescript SDK for Instill AI products
 ### installation
 
 ```
-npm i @instill-ai/typescript-sdk
+npm i instill-sdk
 ```
 
 ```
-yarn add @instill-ai/typescript-sdk
+yarn add instill-sdk
 ```
 
 ```
-pnpm add @instill-ai/typescript-sdk
+pnpm add instill-sdk
 ```
 
 ## Usage:
 
 ```
 // node.js
-const InstillClient = require("@instill-ai/typescript-sdk").default;
+const InstillClient = require("instill-sdk").default;
 
 // next.js
-import InstillClient from "@instill-ai/typescript-sdk";
+import InstillClient from "instill-sdk";
 
 ```
 
@@ -60,7 +60,7 @@ import { useEffect, useState } from "react";
 import InstillClient, {
   Nullable,
   User,
-} from "@instill-ai/typescript-sdk";
+} from "instill-sdk";
 
 export default function TypescriptSdkDemo() {
   const [user, setUser] = useState<User[]>([]);
@@ -101,7 +101,7 @@ import InstillClient, {
   Nullable,
   Pipeline,
   User,
-} from "@instill-ai/typescript-sdk";
+} from "instill-sdk";
 
 export default function TypescriptSdkDemo() {
   const [pipelines, setPipelines] = useState<Pipeline[]>([]);

--- a/examples/next-app/README.md
+++ b/examples/next-app/README.md
@@ -38,7 +38,7 @@ import InstillClient, {
   Nullable,
   Pipeline,
   User,
-} from "@instill-ai/typescript-sdk";
+} from "instill-sdk";
 
 export default function TypescriptSdkDemo() {
   const [pipelines, setPipelines] = useState<Pipeline[]>([]);

--- a/examples/next-app/package.json
+++ b/examples/next-app/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@instill-ai/typescript-sdk": "0.0.11-rc.0",
+    "instill-sdk": "0.0.1",
     "next": "latest",
     "react": "latest",
     "react-dom": "latest"

--- a/examples/next-app/pnpm-lock.yaml
+++ b/examples/next-app/pnpm-lock.yaml
@@ -5,9 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
-  'instill-sdk':
-    specifier: 0.0.11-rc.0
-    version: 0.0.11-rc.0(@instill-ai/design-system@0.49.1)(@instill-ai/design-tokens@0.3.2)(@types/react-dom@18.2.8)(@types/react@18.2.25)(next@13.5.4)(react-dom@18.2.0)(react@18.2.0)
+  instill-sdk:
+    specifier: 0.0.1
+    version: 0.0.1(@instill-ai/design-system@0.49.1)(@instill-ai/design-tokens@0.3.2)(@types/react-dom@18.2.8)(@types/react@18.2.25)(next@13.5.4)(react-dom@18.2.0)(react@18.2.0)
   next:
     specifier: latest
     version: 13.5.4(react-dom@18.2.0)(react@18.2.0)
@@ -258,26 +258,6 @@ packages:
       - '@types/react'
       - '@types/react-dom'
       - debug
-      - react-native
-    dev: false
-
-  /instill-sdk@0.0.1(@instill-ai/design-system@0.49.1)(@instill-ai/design-tokens@0.3.2)(@types/react-dom@18.2.8)(@types/react@18.2.25)(next@13.5.4)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-OvIsgB9lGO3eyt5HS9zpFJt0PPgFhF31M3HX1rg84/0xHmfaga5eHpHlcNskB3jCEIDEHhwslhqqZk763eflHA==}
-    dependencies:
-      '@instill-ai/toolkit': 0.68.0-rc.23(@instill-ai/design-system@0.49.1)(@instill-ai/design-tokens@0.3.2)(@types/react-dom@18.2.8)(@types/react@18.2.25)(next@13.5.4)(react-dom@18.2.0)(react@18.2.0)
-      '@types/json-schema': 7.0.13
-      axios: 1.5.1
-      json-schema: 0.4.0
-      openapi-types: 12.1.3
-    transitivePeerDependencies:
-      - '@instill-ai/design-system'
-      - '@instill-ai/design-tokens'
-      - '@types/react'
-      - '@types/react-dom'
-      - debug
-      - next
-      - react
-      - react-dom
       - react-native
     dev: false
 
@@ -2500,6 +2480,26 @@ packages:
 
   /inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+    dev: false
+
+  /instill-sdk@0.0.1(@instill-ai/design-system@0.49.1)(@instill-ai/design-tokens@0.3.2)(@types/react-dom@18.2.8)(@types/react@18.2.25)(next@13.5.4)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-4sDeYSO5oG2EFvijDMemKI2fnlxl5pPH7H1xgm+BiStWau7g5bhPeFqUnD6wRgF7wwURHMKurrvBNdMbBG3e+g==}
+    dependencies:
+      '@instill-ai/toolkit': 0.68.0-rc.23(@instill-ai/design-system@0.49.1)(@instill-ai/design-tokens@0.3.2)(@types/react-dom@18.2.8)(@types/react@18.2.25)(next@13.5.4)(react-dom@18.2.0)(react@18.2.0)
+      '@types/json-schema': 7.0.13
+      axios: 1.5.1
+      json-schema: 0.4.0
+      openapi-types: 12.1.3
+    transitivePeerDependencies:
+      - '@instill-ai/design-system'
+      - '@instill-ai/design-tokens'
+      - '@types/react'
+      - '@types/react-dom'
+      - debug
+      - next
+      - react
+      - react-dom
+      - react-native
     dev: false
 
   /invariant@2.2.4:

--- a/examples/next-app/pnpm-lock.yaml
+++ b/examples/next-app/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
-  '@instill-ai/typescript-sdk':
+  'instill-sdk':
     specifier: 0.0.11-rc.0
     version: 0.0.11-rc.0(@instill-ai/design-system@0.49.1)(@instill-ai/design-tokens@0.3.2)(@types/react-dom@18.2.8)(@types/react@18.2.25)(next@13.5.4)(react-dom@18.2.0)(react@18.2.0)
   next:
@@ -261,7 +261,7 @@ packages:
       - react-native
     dev: false
 
-  /@instill-ai/typescript-sdk@0.0.11-rc.0(@instill-ai/design-system@0.49.1)(@instill-ai/design-tokens@0.3.2)(@types/react-dom@18.2.8)(@types/react@18.2.25)(next@13.5.4)(react-dom@18.2.0)(react@18.2.0):
+  /instill-sdk@0.0.1(@instill-ai/design-system@0.49.1)(@instill-ai/design-tokens@0.3.2)(@types/react-dom@18.2.8)(@types/react@18.2.25)(next@13.5.4)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-OvIsgB9lGO3eyt5HS9zpFJt0PPgFhF31M3HX1rg84/0xHmfaga5eHpHlcNskB3jCEIDEHhwslhqqZk763eflHA==}
     dependencies:
       '@instill-ai/toolkit': 0.68.0-rc.23(@instill-ai/design-system@0.49.1)(@instill-ai/design-tokens@0.3.2)(@types/react-dom@18.2.8)(@types/react@18.2.25)(next@13.5.4)(react-dom@18.2.0)(react@18.2.0)

--- a/examples/next-app/src/pages/index.tsx
+++ b/examples/next-app/src/pages/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import InstillClient, { Pipeline, User } from "@instill-ai/typescript-sdk";
+import InstillClient, { Pipeline, User } from "instill-sdk";
 
 export default function TypescriptSdkDemo() {
   const [pipelines, setPipelines] = useState<Pipeline[]>([]);
@@ -56,7 +56,7 @@ export default function TypescriptSdkDemo() {
 //   Nullable,
 //   Pipeline,
 //   User,
-// } from "@instill-ai/typescript-sdk";
+// } from "instill-sdk";
 
 // export default function TypescriptSdkDemo() {
 //   const [pipelines, setPipelines] = useState<Pipeline[]>([]);

--- a/examples/node-app/README.md
+++ b/examples/node-app/README.md
@@ -31,7 +31,7 @@ check http://localhost:5000
 
 ```
 const express = require("express");
-const InstillClient = require("@instill-ai/typescript-sdk").default; // If CommonJS style
+const InstillClient = require("instill-sdk").default; // If CommonJS style
 
 const app = express();
 const port = 5000;

--- a/examples/node-app/package.json
+++ b/examples/node-app/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "dependencies": {
-    "@instill-ai/typescript-sdk": "0.0.8-rc.12",
+    "instill-sdk": "0.0.1",
     "express": "^4.18.2"
   },
   "scripts": {

--- a/examples/node-app/pnpm-lock.yaml
+++ b/examples/node-app/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
-  '@instill-ai/typescript-sdk':
+  'instill-sdk':
     specifier: 0.0.8-rc.12
     version: 0.0.8-rc.12(@instill-ai/design-system@0.49.1)(@instill-ai/design-tokens@0.3.2)(next@13.5.3)(react-dom@18.2.0)(react@18.2.0)
   express:
@@ -241,7 +241,7 @@ packages:
       - react-native
     dev: false
 
-  /@instill-ai/typescript-sdk@0.0.8-rc.12(@instill-ai/design-system@0.49.1)(@instill-ai/design-tokens@0.3.2)(next@13.5.3)(react-dom@18.2.0)(react@18.2.0):
+  /instill-sdk@0.0.1(@instill-ai/design-system@0.49.1)(@instill-ai/design-tokens@0.3.2)(next@13.5.3)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-IrvOa6sEce/hHLF+DZwKBEfy9GE5LAmfLjlp4i9Xujcli78N6UwxbhDSYY/gDqXzG0u57iPfkoCds3isTMD9Tw==}
     dependencies:
       '@instill-ai/toolkit': 0.68.0-rc.23(@instill-ai/design-system@0.49.1)(@instill-ai/design-tokens@0.3.2)(next@13.5.3)(react-dom@18.2.0)(react@18.2.0)

--- a/examples/node-app/pnpm-lock.yaml
+++ b/examples/node-app/pnpm-lock.yaml
@@ -5,12 +5,12 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
-  'instill-sdk':
-    specifier: 0.0.8-rc.12
-    version: 0.0.8-rc.12(@instill-ai/design-system@0.49.1)(@instill-ai/design-tokens@0.3.2)(next@13.5.3)(react-dom@18.2.0)(react@18.2.0)
   express:
     specifier: ^4.18.2
     version: 4.18.2
+  instill-sdk:
+    specifier: 0.0.1
+    version: 0.0.1(@instill-ai/design-system@0.49.1)(@instill-ai/design-tokens@0.3.2)(next@13.5.3)(react-dom@18.2.0)(react@18.2.0)
 
 packages:
 
@@ -238,26 +238,6 @@ packages:
       - '@types/react'
       - '@types/react-dom'
       - debug
-      - react-native
-    dev: false
-
-  /instill-sdk@0.0.1(@instill-ai/design-system@0.49.1)(@instill-ai/design-tokens@0.3.2)(next@13.5.3)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-IrvOa6sEce/hHLF+DZwKBEfy9GE5LAmfLjlp4i9Xujcli78N6UwxbhDSYY/gDqXzG0u57iPfkoCds3isTMD9Tw==}
-    dependencies:
-      '@instill-ai/toolkit': 0.68.0-rc.23(@instill-ai/design-system@0.49.1)(@instill-ai/design-tokens@0.3.2)(next@13.5.3)(react-dom@18.2.0)(react@18.2.0)
-      '@types/json-schema': 7.0.13
-      axios: 1.5.1
-      json-schema: 0.4.0
-      openapi-types: 12.1.3
-    transitivePeerDependencies:
-      - '@instill-ai/design-system'
-      - '@instill-ai/design-tokens'
-      - '@types/react'
-      - '@types/react-dom'
-      - debug
-      - next
-      - react
-      - react-dom
       - react-native
     dev: false
 
@@ -2583,6 +2563,26 @@ packages:
 
   /inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+    dev: false
+
+  /instill-sdk@0.0.1(@instill-ai/design-system@0.49.1)(@instill-ai/design-tokens@0.3.2)(next@13.5.3)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-4sDeYSO5oG2EFvijDMemKI2fnlxl5pPH7H1xgm+BiStWau7g5bhPeFqUnD6wRgF7wwURHMKurrvBNdMbBG3e+g==}
+    dependencies:
+      '@instill-ai/toolkit': 0.68.0-rc.23(@instill-ai/design-system@0.49.1)(@instill-ai/design-tokens@0.3.2)(next@13.5.3)(react-dom@18.2.0)(react@18.2.0)
+      '@types/json-schema': 7.0.13
+      axios: 1.5.1
+      json-schema: 0.4.0
+      openapi-types: 12.1.3
+    transitivePeerDependencies:
+      - '@instill-ai/design-system'
+      - '@instill-ai/design-tokens'
+      - '@types/react'
+      - '@types/react-dom'
+      - debug
+      - next
+      - react
+      - react-dom
+      - react-native
     dev: false
 
   /invariant@2.2.4:

--- a/examples/node-app/server.js
+++ b/examples/node-app/server.js
@@ -1,5 +1,5 @@
 const express = require("express");
-const InstillClient = require("@instill-ai/typescript-sdk").default; // If CommonJS style
+const InstillClient = require("instill-sdk").default; // If CommonJS style
 
 const app = express();
 const port = 5000;
@@ -28,7 +28,7 @@ app.listen(port, () => {
 // Local
 
 // const express = require("express");
-// const InstillClient = require("@instill-ai/typescript-sdk").default; // If CommonJS style
+// const InstillClient = require("instill-sdk").default; // If CommonJS style
 
 // const app = express();
 // const port = 5000;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instill-sdk",
-  "version": "0.0.13",
+  "version": "0.0.1",
   "description": "Instill AI's Typescript SDK",
   "repository": "https://github.com/instill-ai/typescript-sdk.git",
   "bugs": "https://github.com/instill-ai/community/issues",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@instill-ai/typescript-sdk",
-  "version": "0.0.12",
+  "name": "instill-sdk",
+  "version": "0.0.13",
   "description": "Instill AI's Typescript SDK",
   "repository": "https://github.com/instill-ai/typescript-sdk.git",
   "bugs": "https://github.com/instill-ai/community/issues",

--- a/release-please/config.json
+++ b/release-please/config.json
@@ -2,8 +2,8 @@
   "packages": {
     ".": {
       "release-type": "node",
-      "package-name": "@instill-ai/typescript-sdk",
-      "component": "@instill-ai/typescript-sdk",
+      "package-name": "instill-sdk",
+      "component": "instill-sdk",
       "draft": false,
       "prerelease": true,
       "bump-minor-pre-major": true,

--- a/release-please/manifest.json
+++ b/release-please/manifest.json
@@ -1,4 +1,4 @@
 {
-  "@instill-ai/typescript-sdk": "0.0.1",
+  "instill-sdk": "0.0.1",
   ".": "0.0.12"
 }


### PR DESCRIPTION
Because

- use new namespace from `@instill-ai/typescript-sdk` --> `instill-sdk`

This commit

- use new namespace from `@instill-ai/typescript-sdk` --> `instill-sdk`
